### PR TITLE
Update Phonix/MatchRatingApproach.cs

### DIFF
--- a/Phonix/MatchRatingApproach.cs
+++ b/Phonix/MatchRatingApproach.cs
@@ -102,11 +102,18 @@ namespace Phonix
                 bool found = false;
                 for (int j = 0; j < large.Length; j++)
                 {
-                    if (small[i] == large[j])
+					try
                     {
-                        small = small.Remove(i, 1);
-                        large = large.Remove(j, 1);
-                        found = true;
+						if (small[i] == large[j])
+						{
+							small = small.Remove(i, 1);
+							large = large.Remove(j, 1);
+							found = true;
+						}
+					}
+                    catch (Exception e)
+                    {
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
Fix for this IndexOutOfBoundsException when doing this:

```
readonly MatchRatingApproach _generator = new MatchRatingApproach();
_generator.MatchRatingCompute("hofer", "marggi")
```